### PR TITLE
Add resource limitation (CPU + mem) for Deb packaging

### DIFF
--- a/contrib/netperf/init.d-collectd-td-deb
+++ b/contrib/netperf/init.d-collectd-td-deb
@@ -21,19 +21,41 @@ logfile="/var/log/collectd-td.log"
 lockfile="/var/lock/$servicename"
 pidfile="/var/run/${servicename}.pid"
 respawn_pidfile="/var/run/respawn-${servicename}.pid"
+cgroup_root="/sys/fs/cgroup"
+cgroup_path="daemons/netperf"
 
 . /lib/lsb/init-functions
+
+# Ubuntu Trusty removes cgconfig for configuring CGroups but does not
+# furnish a replacement. cgroup-lite only provides the CGroups filesystem.
+# Build our configuration directly on that filesystem.  This might break
+# when Debian and/or Ubuntu do provide a replacement.
+configure_cgroup() {
+  local cpu=$cgroup_root/cpu/$cgroup_path
+  local mem=$cgroup_root/memory/$cgroup_path
+  mkdir -p $cpu || log_daemon_msg "Failed to create cgroup $cpu"
+  # TODO(arielshaqed): If Debian doesn't have cgroup memory controller, only
+  # do this when $cgroup_root/memory is loaded.
+  mkdir -p $mem || log_daemon_msg "Failed to create cgroup $mem"
+  echo 1000000 > $cpu/cpu.cfs_period_us
+  echo 1500 > $cpu/cpu.cfs_quota_us
+  echo 180m > $mem/memory.limit_in_bytes
+  # memsw.limit_in_bytes does not exist in Ubuntu Trusty (14.04)
+  echo 0 > $mem/memory.oom_control
+}
 
 join() { local IFS="$1"; shift; echo "$*"; }
 
 start() {
-  local respawn_args="-respawn_pidfile $respawn_pidfile -program_pidfile $pidfile -d -l $logfile"
+  local respawn_args="$respawn -respawn_pidfile $respawn_pidfile -program_pidfile $pidfile -d -l $logfile"
   local cmd="$prog -f -C $dir/etc/collectd-td.conf"
   local vars="MALLOC_ARENA_MAX=1 LD_LIBRARY_PATH=/opt/libgrpc-td/lib"
   local RETVAL=0
   log_daemon_msg "Starting $servicename" "$servicename"
+  configure_cgroup
   env $vars start-stop-daemon --start --pidfile "$respawn_pidfile" \
-    --exec "$respawn" -- $respawn_args $cmd
+    --exec "/usr/bin/cgexec" -- \
+    -g "cpu,memory:$cgroup_path" $respawn_args $cmd
   RETVAL=$?
   log_end_msg $RETVAL
   [ $RETVAL -eq 0 ] && touch "$lockfile"

--- a/contrib/netperf/init.d-collectd-td-deb
+++ b/contrib/netperf/init.d-collectd-td-deb
@@ -38,7 +38,7 @@ configure_cgroup() {
   # do this when $cgroup_root/memory is loaded.
   mkdir -p $mem || log_daemon_msg "Failed to create cgroup $mem"
   echo 1000000 > $cpu/cpu.cfs_period_us
-  echo 1500 > $cpu/cpu.cfs_quota_us
+  echo 15000 > $cpu/cpu.cfs_quota_us
   echo 180m > $mem/memory.limit_in_bytes
   # memsw.limit_in_bytes does not exist in Ubuntu Trusty (14.04)
   echo 0 > $mem/memory.oom_control

--- a/debian/collectd-td.install
+++ b/debian/collectd-td.install
@@ -1,4 +1,4 @@
-etc/collectd-td.conf /opt/collectd-td/etc/
+opt/collectd-td/etc/collectd-td.conf /opt/collectd-td/etc/
 opt/collectd-td/bin/*
 opt/collectd-td/sbin/*
 opt/collectd-td/lib/

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/GoogleCloudPlatform/collectd-netperf/tree/netper
 
 Package: collectd-td
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, liboping0, libltdl7
+Depends: ${shlibs:Depends}, ${misc:Depends}, liboping0, libltdl7, cgroup-lite, cgroup-bin
 Description: Statistics collection daemon
  collectd is a small daemon which collects system information periodically and
  provides mechanisms to monitor and store the values in a variety of ways. It

--- a/debian/rules
+++ b/debian/rules
@@ -98,8 +98,7 @@ install-arch: build
 	ln -s collectd debian/tmp/opt/collectd-td/sbin/collectd-td
 	install -d debian/tmp/opt/collectd-td/etc/
 	sed -i -e 's|@TRUSTED_ROOT_CERTS_BUNDLE@|$(trusted_root_certs_path)|' \
-	    debian/tmp/etc/collectd-td.conf
-	install debian/tmp/etc/collectd-td.conf debian/tmp/opt/collectd-td/etc/
+	    debian/tmp/opt/collectd-td/etc/collectd-td.conf
 	install -d debian/tmp/etc/init.d/
 	install contrib/netperf/init.d-collectd-td-deb debian/tmp/etc/init.d/collectd-td
 	:


### PR DESCRIPTION
Tested on Ubuntu Trusty. Not sure memory limitation will work on all current Debian builds.

Fixes issue #3 

@yosih please review & merge.
