### PR TITLE
Debian packaging: cgroups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,9 @@ install-exec-hook:
 		$(INSTALL) -m 0644 contrib/netperf/collectd-td.conf $(DESTDIR)$(sysconfdir)/collectd-td.conf; \
 	fi;
 
+dist-hook:
+	sed -i 's/git/native/' $(distdir)/debian/source/format
+
 maintainer-clean-local:
 	-rm -f -r libltdl
 	-rm -f INSTALL

--- a/contrib/netperf/init.d-collectd-td-deb
+++ b/contrib/netperf/init.d-collectd-td-deb
@@ -62,7 +62,7 @@ configure_cgroup() {
       cgroup_has_variable memory.limit_in_bytes &&
       cgset -r memory.limit_in_bytes=180m $cgroup_path &&
       (cgset -r memory.memsw_limit_in_bytes=180m $cgroup_path \
-        2>&1 >/dev/null || true) &&
+        >/dev/null 2>&1 || true) &&
       cgset -r memory.oom_control=0 $cgroup_path
     ); then
     cgroup_groups[1]=memory

--- a/contrib/netperf/init.d-collectd-td-deb
+++ b/contrib/netperf/init.d-collectd-td-deb
@@ -39,8 +39,8 @@ configure_cgroup() {
   # instead. This provides a *share* of CPU but does not limit *total* CPU
   # time consumed.
   (
-    cgset -r cpu.cfs_period_us=1000000 &&
-    cgset -r cpu.cfs_quota_us=15000
+    cgset -r cpu.cfs_period_us=1000000 $cgroup_path &&
+    cgset -r cpu.cfs_quota_us=15000 $cgroup_path
   ) || (
     cgset -r cpu.shares=24 $cgroup_path
     # This also means we have to define "cpus" and "mems". Limit those to
@@ -49,16 +49,16 @@ configure_cgroup() {
       cgset -r cpuset.cpus=0 $p
       cgset -r cpuset.mems=0 $p
     done
-  ) || log_failure_msg "Failed to limit CPU"
+  ) || log_warning_msg "Failed to limit CPU"
 
   if (
-      cgset -r memory.limit_in_bytes=180m &&
-      (cgset -r memory.memsw_limit_in_bytes=180m || true) &&
-      cgset -r memory.oom_control=0
+      cgset -r memory.limit_in_bytes=180m $cgroup_path &&
+      (cgset -r memory.memsw_limit_in_bytes=180m $cgroup_path || true) &&
+      cgset -r memory.oom_control=0 $cgroup_path
     ); then
     cgroup_groups[1]=memory
   else
-    log_daemon_msg "Failed to limit mem"
+    log_warning_msg "Failed to limit mem"
   fi
 }
 

--- a/contrib/netperf/init.d-collectd-td-deb
+++ b/contrib/netperf/init.d-collectd-td-deb
@@ -23,6 +23,8 @@ pidfile="/var/run/${servicename}.pid"
 respawn_pidfile="/var/run/respawn-${servicename}.pid"
 cgroup_root="/sys/fs/cgroup"
 cgroup_path="daemons/netperf"
+cgroup_subpaths="daemons daemons/netperf"
+declare -a cgroup_groups
 
 . /lib/lsb/init-functions
 
@@ -31,17 +33,33 @@ cgroup_path="daemons/netperf"
 # Build our configuration directly on that filesystem.  This might break
 # when Debian and/or Ubuntu do provide a replacement.
 configure_cgroup() {
-  local cpu=$cgroup_root/cpu/$cgroup_path
-  local mem=$cgroup_root/memory/$cgroup_path
-  mkdir -p $cpu || log_daemon_msg "Failed to create cgroup $cpu"
-  # TODO(arielshaqed): If Debian doesn't have cgroup memory controller, only
-  # do this when $cgroup_root/memory is loaded.
-  mkdir -p $mem || log_daemon_msg "Failed to create cgroup $mem"
-  echo 1000000 > $cpu/cpu.cfs_period_us
-  echo 15000 > $cpu/cpu.cfs_quota_us
-  echo 180m > $mem/memory.limit_in_bytes
-  # memsw.limit_in_bytes does not exist in Ubuntu Trusty (14.04)
-  echo 0 > $mem/memory.oom_control
+  cgroup_groups[0]=cpu
+  cgcreate -g cpu:$cgroup_path
+  # E.g. Debian does not support quota and period, use cpu.shares
+  # instead. This provides a *share* of CPU but does not limit *total* CPU
+  # time consumed.
+  (
+    cgset -r cpu.cfs_period_us=1000000 &&
+    cgset -r cpu.cfs_quota_us=15000
+  ) || (
+    cgset -r cpu.shares=24 $cgroup_path
+    # This also means we have to define "cpus" and "mems". Limit those to
+    # just the first one.
+    for p in $cgroup_subpaths; do
+      cgset -r cpuset.cpus=0 $p
+      cgset -r cpuset.mems=0 $p
+    done
+  ) || log_failure_msg "Failed to limit CPU"
+
+  if (
+      cgset -r memory.limit_in_bytes=180m &&
+      (cgset -r memory.memsw_limit_in_bytes=180m || true) &&
+      cgset -r memory.oom_control=0
+    ); then
+    cgroup_groups[1]=memory
+  else
+    log_daemon_msg "Failed to limit mem"
+  fi
 }
 
 join() { local IFS="$1"; shift; echo "$*"; }
@@ -53,9 +71,10 @@ start() {
   local RETVAL=0
   log_daemon_msg "Starting $servicename" "$servicename"
   configure_cgroup
+  local cgexec_cgroups=`join ',' ${cgroup_groups[@]}`
   env $vars start-stop-daemon --start --pidfile "$respawn_pidfile" \
     --exec "/usr/bin/cgexec" -- \
-    -g "cpu,memory:$cgroup_path" $respawn_args $cmd
+    -g "${cgexec_cgroups}:$cgroup_path" $respawn_args $cmd
   RETVAL=$?
   log_end_msg $RETVAL
   [ $RETVAL -eq 0 ] && touch "$lockfile"

--- a/contrib/netperf/init.d-collectd-td-deb
+++ b/contrib/netperf/init.d-collectd-td-deb
@@ -28,6 +28,11 @@ declare -a cgroup_groups
 
 . /lib/lsb/init-functions
 
+cgroup_has_variable() {
+  ! cgget -r $1 / 2>&1 |
+    fgrep -e 'No such file or directory' -e 'cannot find controller' > /dev/null
+}
+
 # Ubuntu Trusty removes cgconfig for configuring CGroups but does not
 # furnish a replacement. cgroup-lite only provides the CGroups filesystem.
 # Build our configuration directly on that filesystem.  This might break
@@ -35,16 +40,18 @@ declare -a cgroup_groups
 configure_cgroup() {
   cgroup_groups[0]=cpu
   cgcreate -g cpu:$cgroup_path
-  # E.g. Debian does not support quota and period, use cpu.shares
-  # instead. This provides a *share* of CPU but does not limit *total* CPU
-  # time consumed.
+  
   (
+    cgroup_has_variable cpu.cfs_period_us &&
     cgset -r cpu.cfs_period_us=1000000 $cgroup_path &&
     cgset -r cpu.cfs_quota_us=15000 $cgroup_path
   ) || (
+    # E.g. Debian does not support quota and period, use cpu.shares
+    # instead. This provides a *share* of CPU but does not limit *total* CPU
+    # time consumed.
     cgset -r cpu.shares=24 $cgroup_path
-    # This also means we have to define "cpus" and "mems". Limit those to
-    # just the first one.
+    # We also have to define "cpus" and "mems" along the entire path. Limit
+    # those to just the first one.
     for p in $cgroup_subpaths; do
       cgset -r cpuset.cpus=0 $p
       cgset -r cpuset.mems=0 $p
@@ -52,8 +59,10 @@ configure_cgroup() {
   ) || log_warning_msg "Failed to limit CPU"
 
   if (
+      cgroup_has_variable memory.limit_in_bytes &&
       cgset -r memory.limit_in_bytes=180m $cgroup_path &&
-      (cgset -r memory.memsw_limit_in_bytes=180m $cgroup_path || true) &&
+      (cgset -r memory.memsw_limit_in_bytes=180m $cgroup_path \
+        2>&1 >/dev/null || true) &&
       cgset -r memory.oom_control=0 $cgroup_path
     ); then
     cgroup_groups[1]=memory


### PR DESCRIPTION
This makes Debian and Ubuntu packaging work with CGroups. On Debian 7 we only limit CPU by setting cpu.shares, which is quite weak. But it's the best we can do. If CFS is available, we use that, and if there's a memory controller we add that in too.
