### PR TITLE
RPM packaging: start cgconfig when installing; set RPM version number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5814,6 +5814,8 @@ AC_SUBST(LCC_VERSION_STRING)
 AC_CONFIG_FILES(src/libcollectdclient/collectd/lcc_features.h)
 
 AC_CONFIG_FILES([Makefile src/Makefile src/daemon/Makefile src/collectd.conf src/libcollectdclient/Makefile src/libcollectdclient/libcollectdclient.pc src/liboconfig/Makefile bindings/Makefile bindings/java/Makefile])
+
+AC_CONFIG_FILES(contrib/netperf/collectd-td.spec)
 AC_OUTPUT
 
 if test "x$with_librrd" = "xyes" \

--- a/contrib/netperf/collectd-td.spec.in
+++ b/contrib/netperf/collectd-td.spec.in
@@ -1,4 +1,7 @@
-# Edited by arielshaqed to build OUR plugins (and little else)
+# Edited by arielshaqed to build OUR plugins (and little else).
+#
+# This file is edited by autoconf during configuration to set the
+# version numbers.
 
 #
 # q: What is this ?
@@ -232,10 +235,10 @@
 
 Summary:	Statistics collection daemon for filling RRD files
 Name:		collectd-td
-Version:	5.4.2.926.gcc74cc0
+Version:	@PACKAGE_VERSION@
 Release:	2%{?dist}
 URL:		https://github.com/GoogleCloudPlatform/collectd-netperf
-Source:		collectd-td-5.4.2.926.gcc74cc0.tar.bz2
+Source:		collectd-td-@PACKAGE_VERSION@.tar.bz2
 License:	GPLv2, MIT
 Group:		System Environment/Daemons
 BuildRoot:	%{_tmppath}/%{name}-%{version}-root
@@ -1833,8 +1836,16 @@ if [ $1 -eq 2 ]; then
 fi
 %systemd_post collectd.service
 %else
-/sbin/chkconfig --add cgconfig || :
-/sbin/chkconfig --add collectd-td || :
+/sbin/chkconfig --add cgconfig ||
+    echo 2>&1 '"chkconfig --add cgconfig" failed (keep going)'
+/sbin/chkconfig --add collectd-td ||
+    echo 2>&1 '"chkconfig --add collectd" failed (keep going)'
+levels=`/bin/sed -r -n 's/^ *# *chkconfig: *([0-9]+).*$/\1/p' \
+        /etc/init.d/collectd-td`
+/sbin/chkconfig --levels="$levels" cgconfig on ||
+    echo 2>&1 '"chkconfig --levels=$levels cgconfig on" failed (keep going)'
+/sbin/chkconfig collectd-td on ||
+    echo 2>&1 '"chkconfig collectd-td on" failed (keep going)'
 %endif
 
 %preun

--- a/contrib/netperf/init.d-collectd-td
+++ b/contrib/netperf/init.d-collectd-td
@@ -11,8 +11,17 @@
 #         3.      chkconfig --list collectd-td    # make sure
 #         4.      service collectd-td start
 #
-# description: collectd to report fine-grained TCP statistics to Google \
+#
+### BEGIN INIT INFO
+# Provides: collectd-td
+# Required-Start: cgconfig $network
+# Required-Stop: $network
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: collectd to report fine-grained TCP statistics to Google \
 #              Cloud Latency.
+### END INIT INFO
+#
 # chkconfig: 2345 90 10
 # processname: collectd-td
 


### PR DESCRIPTION
Fixes #14.
1. Add LSB-style init info. Now `chkconfig` can correctly sequence `collectd-td` to start after `cgconfig`.
2. Post-install script also starts `cgconfig`. That is poorly packaged and doesn't start by default at any run-level, so turn it on for every level where `collectd-td` is on. (That does _not_ turn it off for any other run-level).
3. Autoconf spec file so version in RPM always agrees with the git-generated internal version number.
