### PR TITLE
Send deltas of retransmissions count

### DIFF
--- a/contrib/netperf/collectd-td.conf
+++ b/contrib/netperf/collectd-td.conf
@@ -27,9 +27,9 @@ WriteQueueLimitLow 5000
 	ReportByConnections true
 	ReportByPorts false
 
-	TcpInfoField "rtt  GAUGE  uint32:68  rcvd_ack"
-	TcpInfoField "total_retrans  GAUGE uint32:100"
-	TcpInfoField "rttvar  GAUGE uint32:72   rcvd_ack"
+	TcpInfoField "rtt		GAUGE   uint32:68   rcvd_ack"
+	TcpInfoField "delta_retrans	COUNTER uint32:100"
+	TcpInfoField "rttvar		GAUGE   uint32:72   rcvd_ack"
 </Plugin>
   
 <Plugin "WriteGRPC">

--- a/src/tcpconns.c
+++ b/src/tcpconns.c
@@ -61,6 +61,7 @@
 #include "common.h"
 #include "plugin.h"
 #include "safe_iop.h"
+#include "utils_avltree.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -160,9 +161,7 @@ enum tcpi_field_type {
 #define TCPI_FIELD_TYPE_SIZE(type) ((size_t)type)
 struct tcpi_field_selector {
   const char *name;  /* Name of value_list field to report, NULL for last */
-  int ds_type;       /* TODO(arielshaqed): How can we report 64-bit
-                      * counters? (Ours are probably DS_TYPE_COUNTER,
-                      * maybe use that?) */
+  int ds_type;       /* TODO(arielshaqed): No way to report 64-bit values */
   enum tcpi_field_type tcpi_type;
   uint32_t offset;  /* Offset inside tcp_info to read field. Must be aligned. */
   /* TODO(arielshaqed): States in which to record the field? */
@@ -171,6 +170,23 @@ struct tcpi_field_selector {
 static struct tcpi_field_selector *tcpi_fields_to_report = NULL;
 static size_t num_tcpi_fields_to_report = 0;
 static size_t tcpi_fields_to_report_size = 0;
+static size_t num_tcpi_counter_fields = 0;
+
+static uint64_t counter_max_delta = 1000000;
+
+/* Cache for computing deltas of DELTA values. */
+static cdtime_t counter_cache_timeout = DOUBLE_TO_CDTIME_T(120.0);
+struct counter_cache_entry_s {
+  /* Cache entry holds num_tcpi_counter_fields values -- one 64-bit value
+   * for every COUNTER entry in order in tcpi_fields_to_report, This is
+   * later used to compute a new value including wrap-around. */
+  uint64_t *values;
+
+  cdtime_t last_update_time;
+};
+typedef struct counter_cache_entry_s *counter_cache_entry_t;
+static pthread_mutex_t counter_cache_lock = PTHREAD_MUTEX_INITIALIZER;
+static c_avl_tree_t   *counter_cache_tree = NULL;
 #endif
 
 static const char *tcp_state[] =
@@ -318,6 +334,127 @@ static uint32_t count_total[TCP_STATE_MAX + 1];
 
 #if KERNEL_LINUX
 #if HAVE_STRUCT_LINUX_INET_DIAG_REQ
+
+static void counter_cache_init(void) {
+  pthread_mutex_lock(&counter_cache_lock);
+  counter_cache_tree = c_avl_create((void*) strcmp);
+  pthread_mutex_unlock(&counter_cache_lock);
+}
+
+static void counter_cache_free_entry(counter_cache_entry_t entry) {
+  sfree(entry->values);
+  sfree(entry);
+}
+
+/* Returns true and fills in entry with counter cache entry for this key
+ * (connection instance id) if it exists; otherwise returns false and fills
+ * in entry to point at a new an (all-zeroes) entry. Does NOT change
+ * last_update_time or set any values for entry, you need to do that
+ * yourself. */
+static _Bool get_counter_cache_entry(char *key, counter_cache_entry_t *entry) {
+  int ret = 0;
+  int rc;
+  pthread_mutex_lock(&counter_cache_lock);
+  if (c_avl_get(counter_cache_tree, key, (void**)entry) == 0)
+    return 1;
+  /* Not found: create a new instance */
+  key = strdup(key);
+  *entry = malloc(sizeof(**entry));
+  (*entry)->last_update_time = 0;
+  (*entry)->values = calloc(num_tcpi_counter_fields, sizeof(*(*entry)->values));
+  rc = c_avl_insert(counter_cache_tree, key, entry);
+  if (rc > 0) {
+    ERROR("[I; leak] "
+          "Cache inconsistent: expected to insert a new element for %s",
+          key);
+    goto exit;
+  } else if (rc < 0) {
+    ERROR("[I; crash] Cache insert failed for %s", key);
+    sfree(key);
+    counter_cache_free_entry(*entry);
+    *entry = NULL;
+  }
+  ret = 1;
+exit:
+  pthread_mutex_unlock(&counter_cache_lock);
+  return ret;
+}
+
+/* Cleans up cache by removing entries last updated more than
+ * counter_cache_timeout before t.  Returns number of elements removed. */
+/* BUG: NOT CALLED YET! */
+size_t counter_cache_cleanup(cdtime_t t) {
+  size_t i;
+  char **remove_keys = NULL;
+  size_t remove_keys_num = 0;
+  size_t remove_keys_size = 0;
+  c_avl_iterator_t *iter;
+  char *key;
+  counter_cache_entry_t entry;
+  char t_str[32];
+
+  cdtime_to_iso8601(t_str, sizeof(t_str), t);
+  INFO("counter_cache_cleanup: Clean up @%s", t_str);
+
+  pthread_mutex_lock(&counter_cache_lock);
+  iter = c_avl_get_iterator(counter_cache_tree);
+  while (c_avl_iterator_next(iter, (void**)&key, (void**)&entry) == 0) {
+    if (entry->last_update_time < t - counter_cache_timeout) {
+      cdtime_to_iso8601(t_str, sizeof(t_str), entry->last_update_time);
+      DEBUG("counter_cache_cleanup: Remove entry for %s (last update @%s)",
+            t_str);
+
+      if (remove_keys_size < remove_keys_num + 1) {
+        remove_keys_size *= 2;
+        if (remove_keys_size < remove_keys_num + 1)
+          remove_keys_size = remove_keys_num + 1;
+        remove_keys = realloc(
+            remove_keys, remove_keys_size * sizeof(*remove_keys));
+      }
+
+      remove_keys[remove_keys_num++] = key;
+    }
+  }
+
+  for (i = 0; i < remove_keys_num; i++) {
+    entry = NULL;
+    if (!c_avl_remove(counter_cache_tree, remove_keys[i],
+                      NULL, (void**)&entry)) {
+      ERROR("[I] Key-to-remove %s no longer in tree", remove_keys[i]);
+    } else if (entry) {
+      sfree(remove_keys[i]);
+      sfree(entry);
+    }
+  }
+
+  pthread_mutex_unlock(&counter_cache_lock);
+  return remove_keys_num;
+}
+
+static uint64_t get_max_for_field_type(enum tcpi_field_type type) {
+  switch(type) {
+    case UINT8: return 1ULL << 8;
+    case UINT32: return 1ULL << 32;
+    case UINT64: return 0;  /* Arithmetic works when adding and subtracting. */
+    default: return 0;      /* Impossible, but this value might be good. */
+  }
+}
+
+/* Returns a wraparound-adjusted delta for going from old to new in field of
+ * given type. Values > counter_max_delta are ignored and return 0. */
+static uint64_t get_wraparound_delta(
+    enum tcpi_field_type type, uint64_t old, uint64_t new) {
+  uint64_t delta;
+  if (old <= new) {
+    /* Likely case: no wraparound */
+    delta = new - old;
+  }
+  else {
+    delta = get_max_for_field_type(type) - (old - new);
+  }
+  return delta <= counter_max_delta ? delta : 0;
+}
+
 static _Bool parse_ds_type(const char *str, int *ds_type) {
 #define STR_CASE(name) do {                               \
       if (strcasecmp(str, #name) == 0) {                  \
@@ -377,6 +514,8 @@ static _Bool parse_tcpinfo_field_selector(
     ERROR ("Bad DS_TYPE \"%s\" in field selector \"%s\"", token, selector_orig);
     goto exit;
   }
+  if (field->ds_type == DS_TYPE_COUNTER)
+    num_tcpi_counter_fields++;
   if (!(token = strtok_r(NULL, " \t\n,", &parse_ptr))) {
     ERROR ("Field selector \"%s\" missing C_TYPE:OFFSET", selector_orig);
     goto exit;
@@ -743,7 +882,10 @@ static void conn_handle_tcpi(
     const char *state_name = TCP_STATE_MIN <= state && state <= TCP_STATE_MAX ?
         tcp_state[state] : "UNKNOWN";
     int tcpi_field_index;
+    int counter_field_index;
     int value_index;
+    counter_cache_entry_t entry;
+    _Bool in_cache = 0;
     _Bool ok = 1;
 
     vl->values = calloc(num_tcpi_fields_to_report, sizeof(value_t));
@@ -752,7 +894,11 @@ static void conn_handle_tcpi(
     snprintf(vl->plugin_instance, sizeof (vl->plugin_instance),
              "%s:%u_%s:%u_%s", src, sport, dst, dport, state_name);
     sstrncpy (vl->type, "tcp_connections_perf", sizeof (vl->type));
-    for (tcpi_field_index = 0, value_index = 0;
+
+    if (num_tcpi_counter_fields > 0)
+      in_cache = get_counter_cache_entry(vl->plugin_instance, &entry);
+
+    for (tcpi_field_index = 0, value_index = 0, counter_field_index = 0;
          tcpi_field_index < num_tcpi_fields_to_report;
          tcpi_field_index++) {
         const struct tcpi_field_selector *field =
@@ -787,9 +933,24 @@ static void conn_handle_tcpi(
             continue;
         }
         switch (field->ds_type) {
-          case DS_TYPE_COUNTER:
-            vl->values[value_index++].counter = value;
+          case DS_TYPE_COUNTER: {
+            /* Overload "COUNTER" (which
+               https://collectd.org/wiki/index.php/Data_source#Data_source_types
+               says should be divided by delta-T) to compute a simple delta. */
+            assert(num_tcpi_counter_fields > 0);
+            if (in_cache) {
+              vl->values[value_index++].counter =
+                  get_wraparound_delta(field->tcpi_type,
+                                       value,
+                                       entry->values[counter_field_index]);
+            }
+            else {
+              vl->values[value_index++].counter = 0;
+            }
+            /* BUG: Update cache entry! */
+            counter_field_index++;
             break;
+          }
           case DS_TYPE_GAUGE:
             vl->values[value_index++].gauge = value;
             break;
@@ -799,8 +960,7 @@ static void conn_handle_tcpi(
           case DS_TYPE_ABSOLUTE:
             vl->values[value_index++].absolute = value;
             break;
-          default:
-            /* Read configuration should have caught this error */
+          default: /* Read configuration should have caught this error */
             break;
         }
     }
@@ -1140,6 +1300,12 @@ static int conn_config (const char *key, const char *value)
   else if (strcasecmp (key, "ConnectionsAgeLimitSecs") == 0) {
     connections_age_limit_msecs = atof(value) * 1000;
   }
+  else if (strcasecmp (key, "CounterMaxDelta") == 0) {
+    counter_max_delta = atoi(value);
+  }
+  else if (strcasecmp (key, "CounterCacheTimeoutSecs") == 0) {
+    counter_cache_timeout = DOUBLE_TO_CDTIME_T(atof(value));
+  }
   else if (strcasecmp (key, "TCPInfoField") == 0) {
     struct tcpi_field_selector field;
     field.name = NULL;
@@ -1183,6 +1349,8 @@ static int conn_init (void)
     port_collect_listening = 1;
 
 #ifdef HAVE_LINUX_INET_DIAG_H
+  if (num_tcpi_counter_fields > 0)
+    counter_cache_init();
   if (report_by_connections) {  /* Define what dataset we shall be reporting */
     data_set_t data_set;
     size_t i;

--- a/src/write_grpc.c
+++ b/src/write_grpc.c
@@ -174,16 +174,16 @@ static bool encode_int_values(
         continue;
     }
 
-      int_value.label = make_string(ds->ds[i].name);
-      int_value.has_value = true;
-      int_value.value = value;
-      if (!pb_encode_tag_for_field(stream, field))
-        return false;
-      if (!pb_encode_submessage(
-              stream,
-              google_internal_cloudlatencytest_v2_IntValue_fields,
-              &int_value))
-        return false;
+    int_value.label = make_string(ds->ds[i].name);
+    int_value.has_value = true;
+    int_value.value = value;
+    if (!pb_encode_tag_for_field(stream, field))
+      return false;
+    if (!pb_encode_submessage(
+            stream,
+            google_internal_cloudlatencytest_v2_IntValue_fields,
+            &int_value))
+      return false;
   }
   return true;
 }


### PR DESCRIPTION
@yosih please review.
1. Configure retransmissions count as a `COUNTER` (changing its name from `total_retrans` to `delta_retrans` so we don't get confused).
2. Modify `TCPConns` plugin to compute deltas of values configured as COUNTER. This takes wraparound into account.
3. Add some memory control: unused connections are harvested every 2 minutes.
