### PR TITLE
Upgrade to gRPC 0.11.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4614,7 +4614,8 @@ then
 	LDFLAGS="$LDFLAGS $with_grpc_ldflags"
 
 	AC_CHECK_LIB(grpc, grpc_channel_create_call, [with_grpc="yes"], [with_grpc="no (Symbol 'grpc_channel_create_call' not found)"], -lgpr -lpthread -ldl)
-	AC_CHECK_LIB(grpc, grpc_service_account_credentials_create, [with_grpc="yes"], [with_grpc="no (Crypto symbol 'grpc_service_account_credentials_create' not found)"], -lgpr -lpthread -ldl)
+	AC_CHECK_LIB(grpc, grpc_google_compute_engine_credentials_create, [with_grpc="yes"], [with_grpc="no (Symbol 'grpc_google_compute_engine_credentials_create' not found)"], -lgpr -lpthread -ldl)
+	AC_CHECK_LIB(grpc, grpc_service_account_jwt_access_credentials_create, [with_grpc="yes"], [with_grpc="no (Crypto symbol 'grpc_service_account_jwt_access_credentials_create' not found)"], -lgpr -lpthread -ldl)
 
 	CPPFLAGS="$SAVE_CPPFLAGS"
 	LDFLAGS="$SAVE_LDFLAGS"


### PR DESCRIPTION
Mostly this adds "NULL" to various reserved locations. But completion
queue handling is now much simpler -- really only need to read a
single success value for the entire grpc_call_start_batch() call.

First part of fixing #21 

Currently this is unable to use the trusted CAs list in Ubuntu Trusty.
